### PR TITLE
Make it work with `eval-in-project`.

### DIFF
--- a/src/leiningen/nrepl.clj
+++ b/src/leiningen/nrepl.clj
@@ -1,71 +1,9 @@
 (ns leiningen.nrepl
   (:require
-   [clojure.java.io :as io]
-   [nrepl.server :as nrepl.server]
-   [leiningen.core.eval :as eval]))
+   [leiningen.core.eval :as leval]
+   [leiningen.core.project :as lproject]
+   [leiningen.nrepl.core :as nrepl-core]))
 
-(defn- require-and-resolve
-  [thing]
-  (require (symbol (namespace thing)))
-  (resolve thing))
-
-(def resolve-mw-xf
-  (comp (map require-and-resolve)
-        (keep identity)))
-
-(defn- handle-seq-var
-  [var]
-  (let [x @var]
-    (if (sequential? x)
-      (into [] resolve-mw-xf x)
-      [var])))
-
-(def mw-xf
-  (comp (map symbol)
-        resolve-mw-xf
-        (mapcat handle-seq-var)))
-
-(defn- ->mw-list
-  [middleware-var-strs]
-  (into [] mw-xf middleware-var-strs))
-
-(defn- build-handler
-  [middleware]
-  (apply nrepl.server/default-handler (->mw-list middleware)))
-
-(defn start-nrepl
-  "Starts a socket-based nREPL server. Accepts a map with the following keys:
-
-   * :port — defaults to 0, which autoselects an open port
-
-   * :bind — bind address, by default \"::\" (falling back to \"localhost\" if
-     \"::\" isn't resolved by the underlying network stack)
-
-   * :handler — the nREPL message handler to use for each incoming connection;
-     defaults to the result of `(nrepl.server/default-handler)`
-
-   * :middleware - a sequence of vars or string which can be resolved to vars,
-     representing middleware you wish to mix in to the nREPL handler. Vars can
-     resolve to a sequence of vars, in which case they'll be flattened into the
-     list of middleware."
-  [{:keys [handler middleware bind port] :as opts}]
-  (let [handler
-        (if handler
-          (handler)
-          (build-handler middleware))
-
-        {:keys [server-socket port] :as server}
-        (nrepl.server/start-server :handler handler
-                                   :bind (or bind "localhost")
-                                   :port (or port 0))
-
-        bind
-        (-> server-socket (.getInetAddress) (.getHostName))]
-    (doto (io/file ".nrepl-port")
-      (spit port)
-      (.deleteOnExit))
-    (println (format "nREPL server started on port %d on host %s - nrepl://%s:%d" port bind bind port))
-    server))
 
 (defn convert-args
   "Convert the args list to a map."
@@ -75,6 +13,8 @@
        (partition 2)
        (map vec)
        (into {})))
+
+(def nrepl-profile {:dependencies [['nrepl/lein-nrepl "0.1.0-SNAPSHOT"]]})
 
 (defn nrepl
   "Start a headless nREPL server within your project's context.
@@ -98,8 +38,11 @@
   map and passed to `start-nrepl`."
   [project & args]
   (println args)
-  (eval/eval-in-project
-   project
-   `(start-nrepl ~(convert-args args)))
+  (let [profile (or (:nrepl (:profiles project)) nrepl-profile)
+        project (lproject/merge-profiles project [profile])]
+    (leval/eval-in-project
+     project
+     `(nrepl-core/start-nrepl ~(convert-args args))
+     '(require 'leiningen.nrepl.core)))
   ;; block forever, so the process won't end after the server was started
   @(promise))

--- a/src/leiningen/nrepl/core.clj
+++ b/src/leiningen/nrepl/core.clj
@@ -1,0 +1,67 @@
+(ns leiningen.nrepl.core
+  (:require
+   [clojure.java.io :as io]
+   [nrepl.server :as nrepl.server]))
+
+(defn- require-and-resolve
+  [thing]
+  (require (symbol (namespace thing)))
+  (resolve thing))
+
+(def resolve-mw-xf
+  (comp (map require-and-resolve)
+        (keep identity)))
+
+(defn- handle-seq-var
+  [var]
+  (let [x @var]
+    (if (sequential? x)
+      (into [] resolve-mw-xf x)
+      [var])))
+
+(def mw-xf
+  (comp (map symbol)
+        resolve-mw-xf
+        (mapcat handle-seq-var)))
+
+(defn- ->mw-list
+  [middleware-var-strs]
+  (into [] mw-xf middleware-var-strs))
+
+(defn- build-handler
+  [middleware]
+  (apply nrepl.server/default-handler (->mw-list middleware)))
+
+(defn start-nrepl
+  "Starts a socket-based nREPL server. Accepts a map with the following keys:
+
+   * :port — defaults to 0, which autoselects an open port
+
+   * :bind — bind address, by default \"::\" (falling back to \"localhost\" if
+     \"::\" isn't resolved by the underlying network stack)
+
+   * :handler — the nREPL message handler to use for each incoming connection;
+     defaults to the result of `(nrepl.server/default-handler)`
+
+   * :middleware - a sequence of vars or string which can be resolved to vars,
+     representing middleware you wish to mix in to the nREPL handler. Vars can
+     resolve to a sequence of vars, in which case they'll be flattened into the
+     list of middleware."
+  [{:keys [handler middleware bind port] :as opts}]
+  (let [handler
+        (if handler
+          (handler)
+          (build-handler middleware))
+
+        {:keys [server-socket port] :as server}
+        (nrepl.server/start-server :handler handler
+                                   :bind (or bind "localhost")
+                                   :port (or port 0))
+
+        bind
+        (-> server-socket (.getInetAddress) (.getHostName))]
+    (doto (io/file ".nrepl-port")
+      (spit port)
+      (.deleteOnExit))
+    (println (format "nREPL server started on port %d on host %s - nrepl://%s:%d" port bind bind port))
+    server))


### PR DESCRIPTION
WARNING: THIS IS JUST AN EXPERIMENTATION BASED ON MY LIMITED UNDERSTANDING OF LEIN PLUGINS. YOU MAY NOT WANT TO USE THIS APPROACH!

Most probably, the previous version was missing the dependency on this plugin when starting nREPL
within the project context.
This should be solved by merging profiles and adding require (option arg to the `eval-in-project`).
Notice that if you try this without separation of the code to the new `leiningen.nrepl.core`
namespace, you'll end up with the following error:
```
Caused by: java.io.FileNotFoundException: Could not locate leiningen/core/eval__init.class or leiningen/core/eval.clj on classpath.
```

See https://github.com/technomancy/leiningen/blob/master/doc/PLUGINS.md#evaluating-in-project-context